### PR TITLE
Make checks public

### DIFF
--- a/src/main/java/org/incendo/serverlib/forks/Akarin.java
+++ b/src/main/java/org/incendo/serverlib/forks/Akarin.java
@@ -9,7 +9,7 @@ public class Akarin {
 
     private final static java.util.logging.Logger logger = Logger.getLogger(Akarin.class.getName());
 
-    private static boolean unsafeAkarin() {
+    public static boolean unsafeAkarin() {
         try {
             Class.forName("io.akarin.server.Config");
             return true;

--- a/src/main/java/org/incendo/serverlib/forks/KibblePatcher.java
+++ b/src/main/java/org/incendo/serverlib/forks/KibblePatcher.java
@@ -9,7 +9,7 @@ public class KibblePatcher {
 
     private final static java.util.logging.Logger logger = Logger.getLogger(KibblePatcher.class.getName());
 
-    private static boolean unsafeKibblePatcher() {
+    public static boolean unsafeKibblePatcher() {
         try {
             Class.forName("net.kibblelands.server.FastMath");
             return true;

--- a/src/main/java/org/incendo/serverlib/forks/Yatopia.java
+++ b/src/main/java/org/incendo/serverlib/forks/Yatopia.java
@@ -11,7 +11,7 @@ public class Yatopia {
 
     private final static Logger logger = Logger.getLogger(Yatopia.class.getName());
 
-    private static boolean unsafeYatopia() {
+    public static boolean unsafeYatopia() {
         return packageExists("org.yatopiamc")
                 || packageExists("net.yatopia")
                 || packageExists("dev.tr7zw.yatopia");

--- a/src/main/java/org/incendo/serverlib/hybrids/Fabric.java
+++ b/src/main/java/org/incendo/serverlib/hybrids/Fabric.java
@@ -9,7 +9,7 @@ public class Fabric {
 
     private final static java.util.logging.Logger logger = Logger.getLogger(Fabric.class.getName());
 
-    private static boolean incompatibleFabric() {
+    public static boolean incompatibleFabric() {
         try {
             Class.forName("net.fabricmc.loader.launch.knot.KnotServer");
             return true;

--- a/src/main/java/org/incendo/serverlib/hybrids/Forge.java
+++ b/src/main/java/org/incendo/serverlib/hybrids/Forge.java
@@ -9,7 +9,7 @@ public class Forge {
 
     private final static java.util.logging.Logger logger = Logger.getLogger(Forge.class.getName());
 
-    private static boolean incompatibleForge() {
+    public static boolean incompatibleForge() {
         try {
             Class.forName("net.minecraftforge.common.MinecraftForge");
             return true;


### PR DESCRIPTION
Making those checks public allows developers to take action other than displaying a message in console based on the boolean.
This enables for example disabling a plugin if it's on incompatible platform.